### PR TITLE
Update `gear-lib`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2022-12-03
+### Changed
+- Updated `gear-lib`.
+
 ## [0.2.4] - 2022-11-22
 ### Changed
 - Updated `gstd`, `gtest`, `gear-wasm-builder` to the `stable` branch.
@@ -31,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/gear-dapps/non-fungible-token/compare/0.2.4...HEAD
+[Unreleased]: https://github.com/gear-dapps/non-fungible-token/compare/0.2.5...HEAD
+[0.2.4]: https://github.com/gear-dapps/non-fungible-token/compare/0.2.4...0.2.5
 [0.2.4]: https://github.com/gear-dapps/non-fungible-token/compare/0.2.3...0.2.4
 [0.2.3]: https://github.com/gear-dapps/non-fungible-token/compare/0.2.2...0.2.3
 [0.2.2]: https://github.com/gear-dapps/non-fungible-token/compare/0.2.1...0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,8 +785,8 @@ dependencies = [
 
 [[package]]
 name = "gear-lib"
-version = "0.3.2"
-source = "git+https://github.com/gear-dapps/gear-lib.git?tag=0.3.2#f78b0e3b9b0a13a3a2ed25710dbc6ad9e99d4257"
+version = "0.3.3"
+source = "git+https://github.com/gear-dapps/gear-lib.git?branch=as-derive-ords#922d3d94027229a2ca2fce98969bc8adef82dd1d"
 dependencies = [
  "gear-lib-sr25519",
  "gstd",
@@ -797,8 +797,8 @@ dependencies = [
 
 [[package]]
 name = "gear-lib-derive"
-version = "0.3.2"
-source = "git+https://github.com/gear-dapps/gear-lib.git?tag=0.3.2#f78b0e3b9b0a13a3a2ed25710dbc6ad9e99d4257"
+version = "0.3.3"
+source = "git+https://github.com/gear-dapps/gear-lib.git?branch=as-derive-ords#922d3d94027229a2ca2fce98969bc8adef82dd1d"
 dependencies = [
  "gear-lib-macros",
  "proc-macro2",
@@ -809,12 +809,12 @@ dependencies = [
 [[package]]
 name = "gear-lib-macros"
 version = "0.3.2"
-source = "git+https://github.com/gear-dapps/gear-lib.git?tag=0.3.2#f78b0e3b9b0a13a3a2ed25710dbc6ad9e99d4257"
+source = "git+https://github.com/gear-dapps/gear-lib.git?branch=as-derive-ords#922d3d94027229a2ca2fce98969bc8adef82dd1d"
 
 [[package]]
 name = "gear-lib-sr25519"
-version = "0.3.2"
-source = "git+https://github.com/gear-dapps/gear-lib.git?tag=0.3.2#f78b0e3b9b0a13a3a2ed25710dbc6ad9e99d4257"
+version = "0.3.3"
+source = "git+https://github.com/gear-dapps/gear-lib.git?branch=as-derive-ords#922d3d94027229a2ca2fce98969bc8adef82dd1d"
 dependencies = [
  "schnorrkel 0.10.2",
 ]
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "nft"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "gear-lib",
  "gear-lib-derive",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "nft-io"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "gear-lib",
  "gstd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "gear-lib"
 version = "0.3.3"
-source = "git+https://github.com/gear-dapps/gear-lib.git?branch=as-derive-ords#922d3d94027229a2ca2fce98969bc8adef82dd1d"
+source = "git+https://github.com/gear-dapps/gear-lib.git?tag=0.3.3#fd1e05ee79566b1c1c13699624ad2651f44b0f94"
 dependencies = [
  "gear-lib-sr25519",
  "gstd",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "gear-lib-derive"
 version = "0.3.3"
-source = "git+https://github.com/gear-dapps/gear-lib.git?branch=as-derive-ords#922d3d94027229a2ca2fce98969bc8adef82dd1d"
+source = "git+https://github.com/gear-dapps/gear-lib.git?tag=0.3.3#fd1e05ee79566b1c1c13699624ad2651f44b0f94"
 dependencies = [
  "gear-lib-macros",
  "proc-macro2",
@@ -809,12 +809,12 @@ dependencies = [
 [[package]]
 name = "gear-lib-macros"
 version = "0.3.2"
-source = "git+https://github.com/gear-dapps/gear-lib.git?branch=as-derive-ords#922d3d94027229a2ca2fce98969bc8adef82dd1d"
+source = "git+https://github.com/gear-dapps/gear-lib.git?tag=0.3.3#fd1e05ee79566b1c1c13699624ad2651f44b0f94"
 
 [[package]]
 name = "gear-lib-sr25519"
 version = "0.3.3"
-source = "git+https://github.com/gear-dapps/gear-lib.git?branch=as-derive-ords#922d3d94027229a2ca2fce98969bc8adef82dd1d"
+source = "git+https://github.com/gear-dapps/gear-lib.git?tag=0.3.3#fd1e05ee79566b1c1c13699624ad2651f44b0f94"
 dependencies = [
  "schnorrkel 0.10.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 gstd = { git = "https://github.com/gear-tech/gear.git", branch = "stable" }
 primitive-types = { version = "0.12.1", default-features = false }
 nft-io = { path = "io" }
-gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git", branch = "as-derive-ords" }
-gear-lib-derive = { git = "https://github.com/gear-dapps/gear-lib.git", branch = "as-derive-ords" }
+gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git", tag = "0.3.3" }
+gear-lib-derive = { git = "https://github.com/gear-dapps/gear-lib.git", tag = "0.3.3" }
 sp-core-hashing = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nft"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Gear Technologies"]
 edition = "2021"
 
@@ -8,8 +8,8 @@ edition = "2021"
 gstd = { git = "https://github.com/gear-tech/gear.git", branch = "stable" }
 primitive-types = { version = "0.12.1", default-features = false }
 nft-io = { path = "io" }
-gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git", tag = "0.3.2" }
-gear-lib-derive = { git = "https://github.com/gear-dapps/gear-lib.git", tag = "0.3.2" }
+gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git", branch = "as-derive-ords" }
+gear-lib-derive = { git = "https://github.com/gear-dapps/gear-lib.git", branch = "as-derive-ords" }
 sp-core-hashing = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "nft-io"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "MIT"
 authors = ["Gear Technologies"]
 
 [dependencies]
 gstd = { git = "https://github.com/gear-tech/gear.git", branch = "stable" }
-gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git", tag = "0.3.2" }
+gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git", branch = "as-derive-ords" }
 primitive-types = { version = "0.12.1", default-features = false }

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Gear Technologies"]
 
 [dependencies]
 gstd = { git = "https://github.com/gear-tech/gear.git", branch = "stable" }
-gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git", branch = "as-derive-ords" }
+gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git", tag = "0.3.3" }
 primitive-types = { version = "0.12.1", default-features = false }


### PR DESCRIPTION
With the derived `PartialOrd` & `Ord` traits for use in transaction-based contracts.